### PR TITLE
Removes `got` and updates dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "coveralls": "^2.11.4",
     "eslint-config-mongodb-js": "^2.0.0",
-    "got": "^5.1.0",
     "istanbul": "^0.4.0",
     "mocha": "^3.0.2",
     "mongodb-js-fmt": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "test"
   ],
   "dependencies": {
-    "async": "^1.5.0",
+    "async": "^2.1.2",
     "debug": "^2.2.0",
     "lodash.defaults": "^4.0.0",
     "minimist": "^1.2.0",
-    "mongodb-version-list": "^0.0.3",
+    "mongodb-version-list": "^1.0.0",
     "request": "^2.65.0",
     "semver": "^5.0.3"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,5 @@
 var resolve = require('../');
-var got = require('got');
+var request = require('request');
 var assert = require('assert');
 
 function verify(done, query, expectedURL) {
@@ -7,7 +7,7 @@ function verify(done, query, expectedURL) {
     assert.ifError(err);
     assert.equal(res.url, expectedURL);
 
-    got(res.url, {
+    request(res.url, {
       method: 'HEAD'
     }, function(badUrl) {
       if (badUrl) {


### PR DESCRIPTION
See https://github.com/mongodb-js/runner/issues/78

`download-url` had devDependency to `got`, but the latest `got` seems that it has [problem on handling `HEAD` method](https://github.com/sindresorhus/got/issues/162). So we can't update it. 

BTW, `download-url` also depends on `request` already. I think we could simply drop the dependency to `got`.