### PR TITLE
fix(ssl): fixing ssl resolution issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,13 +177,16 @@ function resolve(opts, fn) {
     handler = search.bind(null, opts);
   }
 
-  if (opts.platform === 'osx') {
-    opts.ssl = true;
-  }
-
   handler(function(err, versionId) {
     if (err) {
       return fn(err);
+    }
+
+    // For osx, force ssl on versions >=3.2
+    // TODO: Lets find a more elegant way to try ssl first, and
+    // then resort to non-ssl if it does not exist
+    if (opts.platform === 'osx' && semver.satisfies(versionId, '>=3.2')) {
+      opts.ssl = true;
     }
 
     var extraDash = '-';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -139,6 +139,39 @@ describe('mongodb-download-url', function() {
       verify(done, query,
         'https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.5.13.tgz');
     });
+
+    it('should resolve 3.0.0 without ssl', function(done) {
+      var query = {
+        version: '3.0.0',
+        platform: 'osx',
+        bits: 64
+      };
+
+      verify(done, query,
+        'https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.0.0.tgz');
+    });
+
+    it('should resolve 2.6.0 without ssl', function(done) {
+      var query = {
+        version: '2.6.0',
+        platform: 'osx',
+        bits: 64
+      };
+
+      verify(done, query,
+        'https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-2.6.0.tgz');
+    });
+
+    it('should resolve 3.2.0 with ssl', function(done) {
+      var query = {
+        version: '3.2.0',
+        platform: 'osx',
+        bits: 64
+      };
+
+      verify(done, query,
+        'https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.2.0.tgz');
+    });
   });
 
   // NOTE (imlucas): This is pretty unused as far as I know...


### PR DESCRIPTION
We do not force ssl unless platform is osx AND version >= 3.2.0.
This is short term fix until we have time to come up with a
more elegant solution

Fixes #73