### PR TITLE
fix(ssl): fixing resolution of pre-release candidates

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ function resolve(opts, fn) {
     // For osx, force ssl on versions >=3.2
     // TODO: Lets find a more elegant way to try ssl first, and
     // then resort to non-ssl if it does not exist
-    if (opts.platform === 'osx' && semver.satisfies(versionId, '>=3.2')) {
+    if (opts.platform === 'osx' && semver.gte(versionId, '3.2.0')) {
       opts.ssl = true;
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -172,6 +172,17 @@ describe('mongodb-download-url', function() {
       verify(done, query,
         'https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.2.0.tgz');
     });
+
+    it('should resolve 3.6.0-rc3 with ssl', function(done) {
+      var query = {
+        version: '3.6.0-rc3',
+        platform: 'osx',
+        bits: 64
+      };
+
+      verify(done, query,
+        'https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.0-rc3.tgz');
+    });
   });
 
   // NOTE (imlucas): This is pretty unused as far as I know...


### PR DESCRIPTION
Got burned by the specifics of https://github.com/npm/node-semver#prerelease-tags,
which prevents "satisfies" from working with our original resolution
for pre-release candidates. `semver.gte` does work though