### PR TITLE
[WIP] Build URLs for Linux Distributions

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,6 +74,83 @@ describe('mongodb-download-url', function() {
       verify(done, query,
         'https://fastdl.mongodb.org/linux/mongodb-linux-i686-3.0.7.tgz');
     });
+
+    it('should resolve RHEL 6.2', function(done) {
+      var query = {
+        version: '3.6.2',
+        platform: 'linux',
+        linuxDistro: 'rhel62',
+        bits: 64
+      };
+      verify(done, query,
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel62-3.6.2.tgz');
+    });
+
+    it('should resolve RHEL 7.2', function(done) {
+      var query = {
+        version: '3.6.2',
+        platform: 'linux',
+        linuxDistro: 'rhel72',
+        bits: 64
+      };
+      verify(done, query,
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel72-3.6.2.tgz');
+    });
+
+    it('should resolve SuSE 11', function(done) {
+      var query = {
+        version: '3.6.2',
+        platform: 'linux',
+        linuxDistro: 'suse11',
+        bits: 64
+      };
+      verify(done, query,
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-suse11-3.6.2.tgz');
+    });
+
+    it('should resolve SuSE 12', function(done) {
+      var query = {
+        version: '3.6.2',
+        platform: 'linux',
+        linuxDistro: 'suse12',
+        bits: 64
+      };
+      verify(done, query,
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-suse12-3.6.2.tgz');
+    });
+
+    it('should resolve Ubuntu 16.04', function(done) {
+      var query = {
+        version: '3.6.2',
+        platform: 'linux',
+        linuxDistro: 'ubuntu1604',
+        bits: 64
+      };
+      verify(done, query,
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.6.2.tgz');
+    });
+
+    it('should resolve Ubuntu 14.04', function(done) {
+      var query = {
+        version: '3.6.2',
+        platform: 'linux',
+        linuxDistro: 'ubuntu1404',
+        bits: 64
+      };
+      verify(done, query,
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1404-3.6.2.tgz');
+    });
+
+    it('should resolve Ubuntu 12.04', function(done) {
+      var query = {
+        version: '3.6.2',
+        platform: 'linux',
+        linuxDistro: 'ubuntu1204',
+        bits: 64
+      };
+      verify(done, query,
+        'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1204-3.6.2.tgz');
+    });
   });
 
   describe('windows', function() {


### PR DESCRIPTION
We need to support downloading MongoDB for Linux distributions like RHEL and SuSE.

This is **WIP** cause there's some stuff to verify (below) and I'm testing things in a really slow way, remotely on a RHEL machine. 

- [ ] Use async and remove sync `fs` calls
- [ ] Figure out discrepancies between RHEL 7.0 and `rhel72`
- [ ] Figure out if the Linux urls currently being put together actually exist? 

**NOTE** There are not always existing builds for a version of these distributions, for example, there is no version after `3.6.0-rc0` for `rhel`.  