### PR TITLE
fix(ubuntu): add support for ubuntu distros for v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,12 +255,23 @@ function resolve(opts, fn) {
         ].join('')
       );
     } else if (opts.platform === 'linux') {
-      artifact = format(
-        'mongodb-%s-%s-%s',
-        opts.platform,
-        opts.arch,
-        [opts.debug ? '-debugsymbols-' : '', versionId, opts.ext].join('')
-      );
+      var distro = require('./linuxDistro').getDistro();
+      if (distro && opts.bits === '64' && semver.gte(versionId, '4.0.0')) {
+        artifact = format(
+          'mongodb-%s-%s-%s-%s',
+          opts.platform,
+          opts.arch,
+          distro,
+          [opts.debug ? '-debugsymbols-' : '', versionId, opts.ext].join('')
+        )
+      } else {
+        artifact = format(
+          'mongodb-%s-%s-%s',
+          opts.platform,
+          opts.arch,
+          [opts.debug ? '-debugsymbols-' : '', versionId, opts.ext].join('')
+        );
+      }
     } else {
       artifact =
         'mongodb-' +

--- a/linuxDistro.js
+++ b/linuxDistro.js
@@ -6,7 +6,7 @@ exports.lsbReleaseInfo = lsbReleaseInfo;
 exports.getDistro = getDistro;
 
 function getDistro() {
-    var distroInfo = lsbReleaseInfo();
+    var distroInfo = exports.lsbReleaseInfo();
     switch (distroInfo.distroId) {
         case 'Ubuntu':
             var version = distroInfo.distroVersion.replace('.', '') || '1604';

--- a/linuxDistro.js
+++ b/linuxDistro.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var exec = require('child_process').execSync;
+
+exports.lsbReleaseInfo = lsbReleaseInfo;
+exports.getDistro = getDistro;
+
+function getDistro() {
+    var distroInfo = lsbReleaseInfo();
+    switch (distroInfo.distroId) {
+        case 'Ubuntu':
+            var version = distroInfo.distroVersion.replace('.', '') || '1604';
+            return 'ubuntu' + version;
+        default:
+            return '';
+    }
+}
+
+function lsbReleaseInfo() {
+    var distroId = exec('lsb_release -si', {encoding: 'utf8' });
+    var distroVersion = exec('lsb_release -sr', { encoding: 'utf8' });
+
+    var ret = {
+        distroId: distroId.trim(),
+        distroVersion: distroVersion.trim()
+    };
+
+    return ret;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,42 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -28,6 +64,12 @@
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -389,6 +431,12 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -492,6 +540,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
@@ -584,6 +638,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+    },
+    "lolex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.36.0",
@@ -709,6 +769,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "npmlog": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
@@ -744,6 +817,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -834,6 +924,21 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
+    "sinon": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      }
+    },
     "sshpk": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
@@ -858,6 +963,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -880,6 +994,12 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "semver": "^5.0.3"
   },
   "devDependencies": {
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "sinon": "^7.3.2"
   },
   "keywords": [
     "mongodb",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,8 @@
 var resolve = require('../');
 var request = require('request');
 var assert = require('assert');
+var sinon = require('sinon');
+var linuxDistro = require('../linuxDistro');
 
 function verify(done, query, expectedURL) {
   resolve(query, function(err, res) {
@@ -95,6 +97,59 @@ describe('mongodb-download-url', function() {
         query,
         'https://fastdl.mongodb.org/linux/mongodb-linux-i686-3.0.7.tgz'
       );
+    });
+
+    describe('ubuntu', function() {
+      before(function() {
+        this.sinon = sinon.createSandbox();
+        this.sinon.stub(linuxDistro, 'lsbReleaseInfo').returns({
+          distroId: 'Ubuntu',
+          distroVersion: '16.04'
+        });
+      });
+      after(function() {
+        this.sinon.restore();
+      });
+
+      it('should resolve 4.2.0-rc1 with ubuntu-specific url', function (done) {
+        var query = {
+          version: '4.2.0-rc1',
+          platform: 'linux'
+        };
+
+        verify(
+          done,
+          query,
+          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.0-rc1.tgz'
+        );
+      });
+
+      it('should resolve 4.0.0 with ubuntu-specific url', function (done) {
+        var query = {
+          version: '4.0.0',
+          platform: 'linux'
+        };
+
+        verify(
+          done,
+          query,
+          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.0.tgz'
+        );
+      });
+
+
+      it('should resolve 3.6.0 with generic linux url url', function (done) {
+        var query = {
+          version: '3.6.0',
+          platform: 'linux'
+        };
+
+        verify(
+          done,
+          query,
+          'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.0.tgz'
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Quick fix to get around the fact that we don't have the legacy linux build for 4.2.0. This will fix the issue for ubuntu and allow us to test in travis against `latest`