### PR TITLE
Treat arch: ppc64 as ppc64le

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -15,7 +15,7 @@ if (args.help || args.h) {
   console.error(usage);
   process.exitCode = 1;
 } else {
-  getURL(args)
+  getURL(args as any)
     .then(pkg => console.log(pkg.url))
     .catch(err => { process.nextTick(() => { throw err; }); });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,9 @@ function parseArch(arch: string): string[] {
   if (['arm64', 'aarch64'].includes(arch)) {
     return ['arm64', 'aarch64'];
   }
+  if (['ppc64', 'ppc64le'].includes(arch)) {
+    return ['ppc64', 'ppc64le'];
+  }
   return [arch];
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -329,6 +329,21 @@ describe('mongodb-download-url', function() {
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.11.tgz');
       });
     });
+
+    describe('rhel 7.1 ppc', function() {
+      withFakeDistro('rhel71');
+
+      it('should resolve 4.4.5 with rhel-specific url', async function() {
+        const query = {
+          version: '4.4.5',
+          platform: 'linux',
+          arch: 'ppc64',
+          enterprise: true
+        };
+
+        await verify(query, 'https://downloads.mongodb.com/linux/mongodb-linux-ppc64le-enterprise-rhel71-4.4.5.tgz');
+      });
+    });
   });
 
   describe('windows', function() {
@@ -379,7 +394,7 @@ describe('mongodb-download-url', function() {
         platform: 'win32',
         bits: 64
       } as const;
-      await verify(query, 'https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-4.4.4.zip');
+      await verify(query, 'https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-4.4.5.zip');
     });
   });
 


### PR DESCRIPTION
This should be okay, as mongodb does not provide ppc64be downloads. (For MONGOSH-694)