### PR TITLE
Treat distro: amzn64 as amazon and vice versa

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,14 @@ async function parseTarget(distro: string | undefined, platform: string, archs: 
     const results: PriorityValue<string>[] = [];
     if (distro) {
       results.push({ value: distro, priority: 1000 });
+
+      if (archs.includes('x86_64')) {
+        if (distro === 'amzn64') {
+          results.push({ value: 'amazon', priority: 900 });
+        } else if (distro === 'amazon') {
+          results.push({ value: 'amzn64', priority: 900 });
+        }
+      }
     }
 
     if (archs.includes('x86_64')) {

--- a/src/linux-distro.ts
+++ b/src/linux-distro.ts
@@ -79,9 +79,10 @@ function listDistroIds({ id, version }: { id: string, version: string }): Priori
     case 'sles':
       return [{ value: 'suse' + version.split('.')[0], priority: 100 }];
     case 'amzn':
+    case 'amzn64':
     case 'amazon':
       if (version.match(/^201[0-9]\./)) {
-        return [{ value: 'amazon', priority: 100 }];
+        return [{ value: 'amazon', priority: 100 }, { value: 'amzn64', priority: 100 }];
       } else {
         return [{ value: 'amazon' + version.replace('.', ''), priority: 100 }];
       }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -394,7 +394,7 @@ describe('mongodb-download-url', function() {
         platform: 'win32',
         bits: 64
       } as const;
-      await verify(query, 'https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-4.4.5.zip');
+      await verify(query, kUnknownUrl);
     });
   });
 


### PR DESCRIPTION
The enterprise packages are referred to as `amzn64` and the
community ones as `amazon` for some reason, so accept both inputs.