### PR TITLE
feat: extend support for rapid/continuous releases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -309,13 +309,19 @@ async function options(opts: Options | string = {}): Promise<ProcessedOptions & 
   if (!opts.version) {
     opts.version = process.env.MONGODB_VERSION || 'stable';
   }
+  if (opts.productionOnly) {
+    opts.allowedTags = ['production_release'];
+  }
 
   if (opts.version === 'stable' || opts.version === 'latest' || opts.version === '*') {
     opts.version = '*';
-    opts.productionOnly = true;
+    opts.allowedTags ??= ['production_release'];
+  } else if (opts.version === 'rapid' || opts.version === 'continuous') { // a.k.a. quarterly etc.
+    opts.version = '*';
+    opts.allowedTags ??= ['production_release', 'continuous_release'];
   } else if (opts.version === 'unstable') {
     opts.version = '*';
-    opts.productionOnly = false;
+    opts.allowedTags ??= ['*'];
   }
 
   const processedOptions: ProcessedOptions & VersionListOpts = {

--- a/src/version-list.ts
+++ b/src/version-list.ts
@@ -54,12 +54,20 @@ type FullJSON = {
   versions: VersionInfo[];
 };
 
+export type ReleaseTag =
+  | 'continuous_release'
+  | 'development_release'
+  | 'production_release'
+  | 'release_candidate'
+  | '*';
 export type VersionListOpts = {
   version?: string;
   versionListUrl?: string;
   cachePath?: string;
   cacheTimeMs?: number;
+  // @deprecated use allowedTags instead
   productionOnly?: boolean;
+  allowedTags?: readonly ReleaseTag[];
 };
 
 function defaultCachePath(): string {
@@ -129,8 +137,8 @@ export async function getVersion(opts: VersionListOpts): Promise<VersionInfo> {
   const fullJSON = await getFullJSON(opts);
   let versions = fullJSON.versions;
   versions = versions.filter((info: VersionInfo) => info.downloads.length > 0);
-  if (opts.productionOnly) {
-    versions = versions.filter((info: VersionInfo) => info.production_release);
+  if (opts.allowedTags && !opts.allowedTags.includes('*')) {
+    versions = versions.filter((info: VersionInfo) => opts.allowedTags.some(tag => !!info[tag]));
   }
   if (opts.version && opts.version !== '*') {
     versions = versions.filter((info: VersionInfo) => semver.satisfies(info.version, opts.version));

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -224,6 +224,17 @@ describe('mongodb-download-url', function() {
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2004-4.4.0.tgz');
       });
+
+      it('should resolve 6.2.0 as a continuous release', async function() {
+        const query = {
+          version: '>= 6.1 <= 6.2.0',
+          platform: 'linux',
+          arch: 'arm64',
+          allowedTags: ['production_release', 'continuous_release']
+        } as const;
+
+        await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2004-6.2.0.tgz');
+      });
     });
 
     describe('sunos', function() {
@@ -553,6 +564,13 @@ describe('mongodb-download-url', function() {
     it('should resolve `latest`', async function() {
       const query = {
         version: 'latest'
+      };
+      await verify(query, kUnknownUrl);
+    });
+
+    it('should resolve `rapid`', async function() {
+      const query = {
+        version: 'rapid'
       };
       await verify(query, kUnknownUrl);
     });


### PR DESCRIPTION
Support more easily querying for rapid (a.k.a. continuous, quarterly, etc.) releases.