### PR TITLE
fix: support codenames

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -627,7 +627,7 @@ describe('mongodb-download-url', function() {
     });
 
     it('should handle a version string input', async function() {
-      await verify('4.4.2', kUnknownUrl);
+      await verify('7.0.11', kUnknownUrl);
     });
 
     it('should use the MONGODB_VERSION environment variable for version', async function() {


### PR DESCRIPTION
Adds codename support for systems that don't output an explicit version.

I use Debian Testing, which doesn't report a version ID:

```
seth@seth-pc-tux:~$ cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux trixie/sid"
NAME="Debian GNU/Linux"
VERSION_CODENAME=trixie
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

seth@seth-pc-tux:~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux trixie/sid
Release:	n/a
Codename:	trixie
```

On Debian, each version has a codename. As a Debian Testing user, I'm currently on what will be called Debian 13 in future, but for now is called Debian Testing, code-named Trixie.

To be clear on why I refer to Debian Trixie as version 13, even though it doesn't have that version assigned in the OS itself yet. It's because it will once it has been released, and is already noted as version 13 on it's draft release notes:

> Release Notes for Debian 13 (trixie)
> 
> — https://www.debian.org/releases/trixie/release-notes/

---

Note, Debian 13 is not an officially supported distribution of MongoDB, so the download still won't work for me regardless. But at least now Debian 13 users will have a more helpful error message rather.

(I have found that setting `DISTRO_ID=debian12` works fine for me, though. 👍🏽)

Before, reports that it failed to parse the Linux distro:

```
Error: Could not figure out current Linux distro (Debian, debian)
```

After, similarly to a distro like Ubuntu 12.04, it will report that it couldn't find a download instead:

```
Error: Could not find download URL for version 7.0.11 {
  version: '*',
  enterprise: false,
  crypt_shared: false,
  arch: [ 'x86_64', 'x64' ],
  platform: 'linux',
  allowedTags: [ 'production_release' ],
  target: [
    { value: 'linux_x86_64', priority: 1 },
    { value: 'debian81', priority: 100 },
    { value: 'debian92', priority: 200 },
    { value: 'debian10', priority: 300 },
    { value: 'debian13', priority: 400 }
  ],
  cryptd: false
}
```