### PR TITLE
fix: support rhel8 and rhel80 in a backward compatible way COMPASS-8181

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,13 +3,32 @@ on: [push, pull_request]
 name: CI
 
 jobs:
+  test-deprecated-node:
+    name: Test On Deprecated Node.js Version
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node-version: [12.x, 14.x]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
+      - name: Test
+        run: npm test
+
   test:
     name: Test
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [12.x, 14.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 18.x, 20.x]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,11 @@ async function parseTarget(distro: string | undefined, platform: string, archs: 
       { value: 'darwin', priority: 1 },
       { value: 'macos', priority: 1 }
     ];
+  } else if (['rhel80', 'rhel8'].includes(platform)) {
+    return [
+      { value: 'rhel80', priority: 1 },
+      { value: 'rhel8', priority: 2 }
+    ];
   }
   return [{ value: platform, priority: 1 }];
 }

--- a/src/linux-distro.ts
+++ b/src/linux-distro.ts
@@ -111,15 +111,14 @@ function listDistroIds({ id, version, codename }: { id: string, version: string,
             { value: 'rhel8', priority: ((i + 1) * 100) + 1 }
           ];
         } else {
-          return [{ value: 'rhel' + v, priority: (i + 1) * 100 }];
+          return { value: 'rhel' + v, priority: (i + 1) * 100 };
         }
       };
 
       const want = +version.replace('.', '');
       const known = [55, 57, 62, 67, 70, 71, 72, 80, 81, 82, 83, 90];
       const allowedVersions = known.filter(v => v <= want);
-      const priorities = allowedVersions.map(toRhelVersions);
-      return flattenArray(priorities);
+      return allowedVersions.flatMap(toRhelVersions);
     }
   }
   return [];
@@ -143,13 +142,4 @@ async function lsbReleaseInfo(): Promise<{ id: string, version: string, codename
   ]);
   debug('got lsb info', { id, version, codename });
   return { id, version, codename };
-}
-
-function flattenArray<T>(arrayOfArrays: T[][]): T[] {
-  const result: T[] = [];
-  for (const inner of arrayOfArrays) {
-    result.push(...inner);
-  }
-
-  return result;
 }

--- a/src/linux-distro.ts
+++ b/src/linux-distro.ts
@@ -104,10 +104,22 @@ function listDistroIds({ id, version, codename }: { id: string, version: string,
       return [{ value: 'rhel' + version + '0', priority: 100 }];
     case 'redhatenterprise':
     case 'redhatenterpriseserver': {
+      const toRhelVersions = (v: number, i: number) => {
+        if (v === 80) {
+          return [
+            { value: 'rhel80', priority: (i + 1) * 100 },
+            { value: 'rhel8', priority: ((i + 1) * 100) + 1 }
+          ];
+        } else {
+          return [{ value: 'rhel' + v, priority: (i + 1) * 100 }];
+        }
+      };
+
       const want = +version.replace('.', '');
       const known = [55, 57, 62, 67, 70, 71, 72, 80, 81, 82, 83, 90];
       const allowedVersions = known.filter(v => v <= want);
-      return allowedVersions.map((v, i) => ({ value: 'rhel' + v, priority: (i + 1) * 100 }));
+      const priorities = allowedVersions.map(toRhelVersions);
+      return flattenArray(priorities);
     }
   }
   return [];
@@ -131,4 +143,13 @@ async function lsbReleaseInfo(): Promise<{ id: string, version: string, codename
   ]);
   debug('got lsb info', { id, version, codename });
   return { id, version, codename };
+}
+
+function flattenArray<T>(arrayOfArrays: T[][]): T[] {
+  const result: T[] = [];
+  for (const inner of arrayOfArrays) {
+    result.push(...inner);
+  }
+
+  return result;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -131,32 +131,35 @@ describe('mongodb-download-url', function() {
       await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-i686-3.0.7.tgz');
     });
 
-    describe('ubuntu 16.04', function() {
-      withFakeDistro('ubuntu1604');
+    describe('ubuntu 18.04', function() {
+      withFakeDistro('ubuntu1804');
 
       it('should resolve 4.2.0-rc1 with ubuntu-specific url', async function() {
         const query = {
           version: '4.2.0-rc1',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
-        await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.0-rc1.tgz');
+        await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.0-rc1.tgz');
       });
 
-      it('should resolve 4.0.0 with ubuntu-specific url', async function() {
+      it('should resolve 4.0.0 with ubuntu-specific url and fallback to an older version of ubuntu', async function() {
         const query = {
           version: '4.0.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.0.tgz');
       });
 
-      it('should resolve 3.6.0 with ubuntu-specific url', async function() {
+      it('should resolve 3.6.0 with ubuntu-specific url and fallback to an older version of ubuntu', async function() {
         const query = {
           version: '3.6.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.6.0.tgz');
       });
@@ -168,20 +171,6 @@ describe('mongodb-download-url', function() {
           bits: 64
         } as const;
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.11.tgz');
-      });
-    });
-
-    describe('ubuntu 18.04', function() {
-      it('should resolve 4.4.0 with ubuntu-specific url for ppc64le', async function() {
-        const query = {
-          version: '4.4.0',
-          platform: 'linux',
-          arch: 'ppc64le',
-          enterprise: true,
-          distro: 'ubuntu1804'
-        };
-
-        await verify(query, 'https://downloads.mongodb.com/linux/mongodb-linux-ppc64le-enterprise-ubuntu1804-4.4.0.tgz');
       });
     });
 
@@ -200,8 +189,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.4.4 with ubuntu-specific url', async function() {
         const query = {
           version: '4.4.4',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-4.4.4.tgz');
       });
@@ -209,8 +199,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.2.3 with ubuntu-specific url', async function() {
         const query = {
           version: '4.2.3',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.3.tgz');
       });
@@ -241,8 +232,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 3.5.8 with sunos-specific url', async function() {
         const query = {
           version: '3.5.8',
-          platform: 'sunos'
-        };
+          platform: 'sunos',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/sunos5/mongodb-sunos5-x86_64-3.5.8.tgz');
       });
@@ -254,8 +246,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.4.0 with suse-specific url', async function() {
         const query = {
           version: '4.4.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-suse12-4.4.0.tgz');
       });
@@ -267,8 +260,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.4.0 with suse-specific url', async function() {
         const query = {
           version: '4.4.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-suse15-4.4.0.tgz');
       });
@@ -280,8 +274,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.4.0 with suse-specific url', async function() {
         const query = {
           version: '4.4.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-suse15-4.4.0.tgz');
       });
@@ -293,8 +288,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.4.0 with RHEL-specific url', async function() {
         const query = {
           version: '4.4.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel70-4.4.0.tgz');
       });
@@ -330,8 +326,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 3.0.0 with RHEL-specific url', async function() {
         const query = {
           version: '3.0.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel55-3.0.0.tgz');
       });
@@ -343,8 +340,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.4.4 with debian-specific url', async function() {
         const query = {
           version: '4.4.4',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian92-4.4.4.tgz');
       });
@@ -352,8 +350,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.0.0 with debian-specific url', async function() {
         const query = {
           version: '4.0.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian92-4.0.0.tgz');
       });
@@ -361,8 +360,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 3.6.0 with debian-specific url', async function() {
         const query = {
           version: '3.6.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian81-3.6.0.tgz');
       });
@@ -383,8 +383,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.4.4 with debian-specific url', async function() {
         const query = {
           version: '4.4.4',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian10-4.4.4.tgz');
       });
@@ -392,8 +393,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.2.1 with debian-specific url', async function() {
         const query = {
           version: '4.2.1',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian10-4.2.1.tgz');
       });
@@ -401,8 +403,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 4.1.1 with debian-specific url', async function() {
         const query = {
           version: '4.1.1',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian92-4.1.1.tgz');
       });
@@ -410,8 +413,9 @@ describe('mongodb-download-url', function() {
       it('should resolve 3.6.0 with debian-specific url', async function() {
         const query = {
           version: '3.6.0',
-          platform: 'linux'
-        };
+          platform: 'linux',
+          bits: 64
+        } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian81-3.6.0.tgz');
       });
@@ -625,8 +629,9 @@ describe('mongodb-download-url', function() {
       const query = {
         version: 'latest-alpha',
         platform: 'windows',
-        enterprise: true
-      };
+        enterprise: true,
+        bits: 64
+      } as const;
       await verify(query, 'https://downloads.mongodb.com/windows/mongodb-windows-x86_64-enterprise-latest.zip');
     });
 
@@ -635,8 +640,9 @@ describe('mongodb-download-url', function() {
         version: 'latest-alpha',
         platform: 'linux',
         distro: 'ubuntu2004',
-        enterprise: true
-      };
+        enterprise: true,
+        bits: 64
+      } as const;
       await verify(query, 'https://downloads.mongodb.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2004-latest.tgz');
     });
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -300,6 +300,30 @@ describe('mongodb-download-url', function() {
       });
     });
 
+    describe('RHEL 8.0', function() {
+      withFakeDistro('rhel80');
+
+      it('should resolve 6.0.17 with new schema RHEL-specific url', async function() {
+        const query = {
+          version: '6.0.17',
+          platform: 'linux',
+          bits: 64
+        } as const;
+
+        await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel8-6.0.17.tgz');
+      });
+
+      it('should resolve 6.0.16 with old schema RHEL-specific url', async function() {
+        const query = {
+          version: '6.0.16',
+          platform: 'linux',
+          bits: 64
+        } as const;
+
+        await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel80-6.0.16.tgz');
+      });
+    });
+
     describe('RHEL 5.5', function() {
       withFakeDistro('rhel55');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,8 @@
     "strictNullChecks": false,
     "declaration": true,
     "removeComments": true,
-    "target": "es2018",
-    "lib": ["es2018"],
+    "target": "es2019",
+    "lib": ["es2019"],
     "outDir": "./lib",
     "moduleResolution": "node",
     "module": "commonjs"


### PR DESCRIPTION
With this change, we support rhel8 and rhel80 independently whenever we pass a target or it's guessed. It downloads the corresponding version, rhel8 for latest builds, rhel80 for older builds.

```sh
# Download latest version (uses rhel80 as platform, downloads rhel8)
./bin/mongodb-download-url.js --version 6.0.x --platform rhel80 --bits x86_64 
https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel8-6.0.17.tgz

# Downloads latest version (uses rhel8 platform, downloads rhel8)
./bin/mongodb-download-url.js --version 6.0.x --platform rhel8 --bits x86_64 
https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel8-6.0.17.tgz

# Downloads a legacy version version (uses rhel8 platform, downloads rhel80)
./bin/mongodb-download-url.js --version 6.0.16 --platform rhel8 --bits x86_64
https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel80-6.0.16.tgz

# Downloads a legacy version (uses rhel80 platform, downloads rhel80)
./bin/mongodb-download-url.js --version 6.0.16 --platform rhel80 --bits x86_64
https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel80-6.0.16.tgz
```