### PR TITLE
fix: support rhel8 for versions other than RHEL 8.0 specifically

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -181,11 +181,6 @@ async function parseTarget(distro: string | undefined, platform: string, archs: 
       { value: 'darwin', priority: 1 },
       { value: 'macos', priority: 1 }
     ];
-  } else if (['rhel80', 'rhel8'].includes(platform)) {
-    return [
-      { value: 'rhel80', priority: 1 },
-      { value: 'rhel8', priority: 2 }
-    ];
   }
   return [{ value: platform, priority: 1 }];
 }

--- a/src/linux-distro.ts
+++ b/src/linux-distro.ts
@@ -71,7 +71,8 @@ function listDistroIds({ id, version, codename }: { id: string, version: string,
       if (major >= 18) results.push({ value: 'ubuntu1804', priority: 400 });
       if (major >= 20) results.push({ value: 'ubuntu2004', priority: 500 });
       if (major >= 22) results.push({ value: 'ubuntu2204', priority: 600 });
-      if (major > 22) results.push({ value: 'ubuntu' + version.replace('.', '') + '04', priority: 700 });
+      if (major >= 24) results.push({ value: 'ubuntu2404', priority: 700 });
+      if (major > 24) results.push({ value: 'ubuntu' + version.replace('.', '') + '04', priority: 700 });
       return results;
     }
     case 'debian': {
@@ -84,6 +85,7 @@ function listDistroIds({ id, version, codename }: { id: string, version: string,
         if (codename === 'bullseye') results.push({ value: 'debian11', priority: 200 });
         if (codename === 'bookworm') results.push({ value: 'debian12', priority: 300 });
         if (codename === 'trixie') results.push({ value: 'debian13', priority: 400 });
+        if (codename === 'forky') results.push({ value: 'debian14', priority: 500 });
       }
       return results;
     }
@@ -104,21 +106,13 @@ function listDistroIds({ id, version, codename }: { id: string, version: string,
       return [{ value: 'rhel' + version + '0', priority: 100 }];
     case 'redhatenterprise':
     case 'redhatenterpriseserver': {
-      const toRhelVersions = (v: number, i: number) => {
-        if (v === 80) {
-          return [
-            { value: 'rhel80', priority: (i + 1) * 100 },
-            { value: 'rhel8', priority: ((i + 1) * 100) + 1 }
-          ];
-        } else {
-          return { value: 'rhel' + v, priority: (i + 1) * 100 };
-        }
-      };
-
+      // Since releases made in Aug 2024, the server uses 'rhel8' instead of 'rhel8x'
+      // for 8.x releases, so we multiply low version numbers by 10 and give them
+      // the highest priority in that class (e.g. 'rhel8' trumps 'rhel83')
       const want = +version.replace('.', '');
-      const known = [55, 57, 62, 67, 70, 71, 72, 80, 81, 82, 83, 90];
-      const allowedVersions = known.filter(v => v <= want);
-      return allowedVersions.flatMap(toRhelVersions);
+      const known = [55, 57, 62, 67, 70, 71, 72, 80, 81, 82, 83, 8, 90, 93, 9];
+      const allowedVersions = known.filter(v => v <= want || (v < 50 && v * 10 <= want));
+      return allowedVersions.map((v, i) => ({ value: 'rhel' + v, priority: (i + 1) * 100 }));
     }
   }
   return [];

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -296,6 +296,20 @@ describe('mongodb-download-url', function() {
       });
     });
 
+    describe('RHEL 8.3', function() {
+      withFakeDistro('rhel83');
+
+      it('should resolve 7.0.14 with new schema RHEL-specific url', async function() {
+        const query = {
+          version: '7.0.14',
+          platform: 'linux',
+          bits: 64
+        } as const;
+
+        await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel8-7.0.14.tgz');
+      });
+    });
+
     describe('RHEL 8.0', function() {
       withFakeDistro('rhel80');
 


### PR DESCRIPTION
We have quite a bit of red in mongosh's CI on RHEL 8.x versions right now that aren't RHEL 8.0 specifically