### PR TITLE
fix: Support requesting a rhel release with a single digit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Lookup download URLs for MongoDB versions.",
   "scripts": {
     "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint-fix": "eslint src/**/*.ts test/**/*.ts --fix",
     "test": "npm run lint && npm run build && nyc -r text -r html mocha --colors -r ts-node/register test/*.ts",
     "build": "npm run compile-ts && gen-esm-wrapper . ./.esm-wrapper.mjs",
     "prepare": "npm run build",

--- a/src/linux-distro.ts
+++ b/src/linux-distro.ts
@@ -109,9 +109,16 @@ function listDistroIds({ id, version, codename }: { id: string, version: string,
       // Since releases made in Aug 2024, the server uses 'rhel8' instead of 'rhel8x'
       // for 8.x releases, so we multiply low version numbers by 10 and give them
       // the highest priority in that class (e.g. 'rhel8' trumps 'rhel83')
-      const want = +version.replace('.', '');
+      let want = +version.replace('.', '');
+
+      // If the desired version is supplied as a single digit, assume the user wants
+      // the latest release in that series - e.g. rhel7 should return rhel72
+      if (want < 10) {
+        want = want * 10 + 9;
+      }
       const known = [55, 57, 62, 67, 70, 71, 72, 80, 81, 82, 83, 8, 90, 93, 9];
       const allowedVersions = known.filter(v => v > 50 ? v <= want : v * 10 <= want);
+
       return allowedVersions.map((v, i) => ({ value: 'rhel' + v, priority: (i + 1) * 100 }));
     }
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,7 @@ import resolve, { Options, clearCache } from '../';
 
 const kUnknownUrl = Symbol('kUnknownUrl');
 
-async function verify(query: Options | string, expectedURL: string | typeof kUnknownUrl): Promise<void> {
+async function verify(query: Options | string | undefined, expectedURL: string | typeof kUnknownUrl): Promise<void> {
   const res = await resolve(query);
   if (expectedURL !== kUnknownUrl) {
     assert.strictEqual(res.url, expectedURL);
@@ -355,6 +355,48 @@ describe('mongodb-download-url', function() {
         } as const;
 
         await verify(query, 'https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel55-3.0.0.tgz');
+      });
+    });
+
+    describe('RHEL 7', function() {
+      withFakeDistro('rhel7');
+
+      it('should resolve 7.2 with RHEL-specific url', async function() {
+        const query = {
+          platform: 'linux',
+          arch: 's390x',
+          enterprise: true,
+          version: '6.0.19'
+        } as const;
+
+        await verify(query, 'https://downloads.mongodb.com/linux/mongodb-linux-s390x-enterprise-rhel72-6.0.19.tgz');
+      });
+    });
+
+    describe('RHEL 8', function() {
+      withFakeDistro('rhel8');
+
+      it('should resolve zseries with RHEL8.3-specific url', async function() {
+        const query = {
+          platform: 'linux',
+          arch: 's390x',
+          enterprise: true,
+          version: '6.0.19'
+        } as const;
+
+        // We don't have zseries release tagged as rhel8, so this should fallback to rhel83 as the latest one
+        await verify(query, 'https://downloads.mongodb.com/linux/mongodb-linux-s390x-enterprise-rhel83-6.0.19.tgz');
+      });
+
+      it('should resolve x64 with RHEL8-specific url', async function() {
+        const query = {
+          platform: 'linux',
+          enterprise: true,
+          version: '6.0.19',
+          bits: 64
+        } as const;
+
+        await verify(query, 'https://downloads.mongodb.com/linux/mongodb-linux-x86_64-enterprise-rhel8-6.0.19.tgz');
       });
     });
 


### PR DESCRIPTION
This makes it possible to supply a distro id for rhel with a single digit representing the major release version. The resolved rhel version will be the highest possible minor version from that major release series. For example `rhel7` will resolve the url for `rhel72`.